### PR TITLE
Add PR description (body) to CSV output

### DIFF
--- a/agile_calculator/records/pull_request_base.py
+++ b/agile_calculator/records/pull_request_base.py
@@ -6,6 +6,7 @@ from agile_calculator.records.extracted_record import ExtractedRecord
 class PullRequestBase(ExtractedRecord):
     number: int | None = None
     title: str | None = None
+    body: str | None = None
     draft: bool | None = None
     user: str | None = None
     created_at: datetime | None = None

--- a/agile_calculator/tasks/extractors/github/pull_request_extractor.py
+++ b/agile_calculator/tasks/extractors/github/pull_request_extractor.py
@@ -32,6 +32,7 @@ class PullRequestExtractor(GitHubExtractor):
             record = PullRequestRecord(
                 number=pr.number,
                 title=pr.title,
+                body=pr.body,
                 draft=pr.draft,
                 user=pr.user.login,
                 created_at=pr.created_at,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,13 @@ def mock_pull_request_factory():
         state="closed",
         merged=False,
         base_ref="main",
+        body="Mock description",
     ):
         """Helper function to create a mock pull request with specified attributes."""
         mock_pr = MagicMock()
         mock_pr.number = number
         mock_pr.title = title
+        mock_pr.body = body
         mock_pr.draft = False
         mock_pr.user.login = user_login
         mock_pr.created_at = created_at

--- a/tests/tasks/transformers/test_pull_request_details_transformer.py
+++ b/tests/tasks/transformers/test_pull_request_details_transformer.py
@@ -10,7 +10,7 @@ class TestPullRequestDetailsTransformer:
         """
         mock_record = MagicMock(spec=PullRequestRecord)
         mock_record.model_dump.return_value = {
-            "number": 1, "title": "Test", "draft": False, "user": "testuser",
+            "number": 1, "title": "Test", "body": "test body", "draft": False, "user": "testuser",
             "created_at": None, "updated_at": None, "merged_at": None,
             "closed_at": None, "state": "closed", "base_ref": "main",
             "head_ref": "feature", "merged": False, "merge_commit_sha": None,
@@ -23,6 +23,7 @@ class TestPullRequestDetailsTransformer:
         assert all(isinstance(r, PullRequestDetailsRecord) for r in result)
         assert result[0].number == 1
         assert result[0].title == "Test"
+        assert result[0].body == "test body"
 
     def test_pull_request_details_transformer_maps_record(self):
         """
@@ -31,6 +32,7 @@ class TestPullRequestDetailsTransformer:
         pr = PullRequestRecord(
             number=1,
             title="Test PR",
+            body="test body description",
             draft=False,
             user="user1",
             created_at=None,
@@ -56,6 +58,7 @@ class TestPullRequestDetailsTransformer:
         assert isinstance(details, PullRequestDetailsRecord)
         assert details.number == pr.number
         assert details.title == pr.title
+        assert details.body == pr.body
         assert details.user == pr.user
         assert details.state == pr.state
         assert details.base_ref == pr.base_ref


### PR DESCRIPTION
Add `body` field to `PullRequestBase` and `PullRequestExtractor` to include pull request description in the generated CSV.
This aligns the CSV output with the GitHub API `body` attribute.
Verified with updated tests in `tests/tasks/extractors/github/test_pull_request_extractor.py` and `tests/tasks/transformers/test_pull_request_details_transformer.py`.


---
*PR created automatically by Jules for task [8644593655552036354](https://jules.google.com/task/8644593655552036354) started by @KentFujii*